### PR TITLE
19 bug filters arent deleted

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: DetectoR
 Title: Stay Safe; Don't Miss Any Adverse-Event Signal
-Version: 3.0.1.9001
+Version: 3.0.1.9002
 Authors@R: c(
     person("Carlos", "Fernandez-Escobar", , "carlos.fernandez4.ext@bayer.com", role = c("aut", "cre")),
     person("Steffen", "Jeske", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Imports:
     readr,
     rlang,
     shiny,
+    shiny.destroy,
     shinycssloaders,
     shinydashboard,
     shinyWidgets,

--- a/R/mod_filter.R
+++ b/R/mod_filter.R
@@ -183,103 +183,107 @@ mod_filter_server <- function(id, r) {
       }
     })
     # Update filter buttons ----
-    shiny::observeEvent(selected_filters(), {
-      shiny::req(r$adae_data, r$adsl_data)
-      adae_data <- r$adae_data
-      adsl_data <- r$adsl_data
-      adae_names <- r$adae_variable_names
-      adsl_names <- r$adsl_variable_names
-      selected_filters <- selected_filters()
-      active_filters <- active_filters()
-      new_filters <- selected_filters[
-        !selected_filters %in% active_filters
-      ]
-      deselected_filters <- active_filters[
-        !active_filters %in% selected_filters
-      ]
-      ## Remove buttons for deselected filters ----
-      for (i in seq_along(deselected_filters)) {
-        id <- deselected_filters[i]
-        shiny::removeUI(selector = paste0("#", id))
-      }
-      ## Add buttons for new filter variables ----
-      for (i in seq_along(new_filters)) {
-        id <- new_filters[i]
-        variable_name <- stringr::str_remove(id, "^filter_")
-        if (variable_name %in% colnames(adae_data)) {
-          variable <- adae_data |> dplyr::pull(variable_name)
-          variable_label <- adae_names[adae_names == variable_name] |>
-            names()
-        } else if (variable_name %in% colnames(adsl_data)) {
-          variable <- adsl_data |> dplyr::pull(variable_name)
-          variable_label <- adsl_names[adsl_names == variable_name] |>
-            names()
+    shiny::observeEvent(
+      selected_filters(),
+      ignoreNULL = FALSE,
+      {
+        shiny::req(r$adae_data, r$adsl_data)
+        adae_data <- r$adae_data
+        adsl_data <- r$adsl_data
+        adae_names <- r$adae_variable_names
+        adsl_names <- r$adsl_variable_names
+        selected_filters <- selected_filters()
+        active_filters <- active_filters()
+        new_filters <- selected_filters[
+          !selected_filters %in% active_filters
+        ]
+        deselected_filters <- active_filters[
+          !active_filters %in% selected_filters
+        ]
+        ## Remove buttons for deselected filters ----
+        for (i in seq_along(deselected_filters)) {
+          id <- deselected_filters[i]
+          shiny.destroy::removeInput(id)
         }
-        shiny::insertUI(
-          selector = "#placeholder",
-          ui = shiny::tags$div(
-            # Treatment-emergent flag selected by default
-            if (variable_name == r$treatment_emergent_flag_variable) {
-              choices <- unique(variable)
-              shinyWidgets::pickerInput(
-                inputId = ns(id),
-                label = variable_label,
-                choices = choices,
-                selected = r$treatment_emergent_flag_value,
-                multiple = TRUE,
-                options = picker_input_options()
-              )
-            } else if (!is.numeric(variable)) {
-              # With non-numeric variables, use pickerInput
-              choices <- unique(variable)
-              shinyWidgets::pickerInput(
-                inputId = ns(id),
-                label = variable_label,
-                choices = choices,
-                selected = choices,
-                multiple = TRUE,
-                options = picker_input_options()
-              )
-            } else if (is.numeric(variable)) {
-              # With numeric variables, use sliderInput
-              min_value <- min(variable, na.rm = TRUE)
-              max_value <- max(variable, na.rm = TRUE)
-              if (is.integer(variable)) {
-                # With integer variables, use sliderInput with steps of 1
-                step <- 1
-                sep <- ""
-                ticks <- FALSE
-              } else if (!is.integer(variable)) {
-                # With continuous variables, default values
-                step <- NULL
-                sep <- ","
-                ticks <- TRUE
-              }
-              shiny::sliderInput(
-                inputId = ns(id),
-                label = variable_name,
-                value = c(min_value, max_value),
-                min = min_value,
-                max = max_value,
-                step = step,
-                sep = sep,
-                ticks = ticks
-              )
-            },
-            id = id,
-            class = "detector-filter"
+        ## Add buttons for new filter variables ----
+        for (i in seq_along(new_filters)) {
+          id <- new_filters[i]
+          variable_name <- stringr::str_remove(id, "^filter_")
+          if (variable_name %in% colnames(adae_data)) {
+            variable <- adae_data |> dplyr::pull(variable_name)
+            variable_label <- adae_names[adae_names == variable_name] |>
+              names()
+          } else if (variable_name %in% colnames(adsl_data)) {
+            variable <- adsl_data |> dplyr::pull(variable_name)
+            variable_label <- adsl_names[adsl_names == variable_name] |>
+              names()
+          }
+          shiny::insertUI(
+            selector = "#placeholder",
+            ui = shiny::tags$div(
+              # Treatment-emergent flag selected by default
+              if (variable_name == r$treatment_emergent_flag_variable) {
+                choices <- unique(variable)
+                shinyWidgets::pickerInput(
+                  inputId = ns(id),
+                  label = variable_label,
+                  choices = choices,
+                  selected = r$treatment_emergent_flag_value,
+                  multiple = TRUE,
+                  options = picker_input_options()
+                )
+              } else if (!is.numeric(variable)) {
+                # With non-numeric variables, use pickerInput
+                choices <- unique(variable)
+                shinyWidgets::pickerInput(
+                  inputId = ns(id),
+                  label = variable_label,
+                  choices = choices,
+                  selected = choices,
+                  multiple = TRUE,
+                  options = picker_input_options()
+                )
+              } else if (is.numeric(variable)) {
+                # With numeric variables, use sliderInput
+                min_value <- min(variable, na.rm = TRUE)
+                max_value <- max(variable, na.rm = TRUE)
+                if (is.integer(variable)) {
+                  # With integer variables, use sliderInput with steps of 1
+                  step <- 1
+                  sep <- ""
+                  ticks <- FALSE
+                } else if (!is.integer(variable)) {
+                  # With continuous variables, default values
+                  step <- NULL
+                  sep <- ","
+                  ticks <- TRUE
+                }
+                shiny::sliderInput(
+                  inputId = ns(id),
+                  label = variable_name,
+                  value = c(min_value, max_value),
+                  min = min_value,
+                  max = max_value,
+                  step = step,
+                  sep = sep,
+                  ticks = ticks
+                )
+              },
+              id = id,
+              class = "detector-filter"
+            )
           )
-        )
+        }
+        ## Update active filters ----
+        active_filters(selected_filters())
       }
-      ## Update active filters ----
-      active_filters(selected_filters())
-    })
+    )
     # Remove filter button ----
     shiny::observeEvent(input$remove_filter, {
       # Remove filters from UI
       for (i in seq_along(active_filters())) {
         id <- active_filters()[i]
-        shiny::removeUI(paste0("#", id))
+        shiny.destroy::removeInput(id)
       }
       # Remove filter from reactive value of active filters
       active_filters(NULL)

--- a/manifest.json
+++ b/manifest.json
@@ -4277,6 +4277,40 @@
         "Built": "R 4.5.0; ; 2025-12-02 12:29:03 UTC; unix"
       }
     },
+    "shiny.destroy": {
+      "Source": "CRAN",
+      "Repository": "https://packagemanager.posit.co/cran/latest",
+      "description": {
+        "Package": "shiny.destroy",
+        "Type": "Package",
+        "Title": "Create Destroyable Modules in 'Shiny'",
+        "Version": "0.1.0",
+        "Authors@R": "person(\"Ashley\", \"Baldry\", email = \"arbaldry91@gmail.com\", role = c(\"aut\", \"cre\"))",
+        "Description": "Enables the complete removal of various 'Shiny' components, such\n    as inputs, outputs and modules. It also aids in the removal of observers that have been \n    created in dynamically created modules.",
+        "License": "MIT + file LICENSE",
+        "Encoding": "UTF-8",
+        "Imports": "purrr, rlang, shiny",
+        "Suggests": "bslib, htmltools, knitr, rmarkdown, shinytest2, spelling,\ntestthat (>= 3.0.0)",
+        "Config/testthat/edition": "3",
+        "Language": "en-GB",
+        "RoxygenNote": "7.3.2",
+        "VignetteBuilder": "knitr",
+        "NeedsCompilation": "no",
+        "Packaged": "2024-09-16 19:52:28 UTC; arbal",
+        "Author": "Ashley Baldry [aut, cre]",
+        "Maintainer": "Ashley Baldry <arbaldry91@gmail.com>",
+        "Repository": "RSPM",
+        "Date/Publication": "2024-09-17 12:30:02 UTC",
+        "Built": "R 4.5.0; ; 2025-04-08 07:02:32 UTC; unix",
+        "RemoteType": "standard",
+        "RemoteRef": "shiny.destroy",
+        "RemotePkgRef": "shiny.destroy",
+        "RemoteRepos": "https://packagemanager.posit.co/cran/__linux__/jammy/latest",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "source",
+        "RemoteSha": "0.1.0"
+      }
+    },
     "shinyWidgets": {
       "Source": "CRAN",
       "Repository": "https://packagemanager.posit.co/cran/latest",
@@ -5317,7 +5351,7 @@
       "checksum": "f4994f578580807f5a09ff5c0a07b049"
     },
     ".Rprofile": {
-      "checksum": "a2c7260c5f398c44c89ac6a9b96b4292"
+      "checksum": "4e3304f5f9504c0fbae51e76dab4f974"
     },
     ".vscode/extensions.json": {
       "checksum": "90d7891f1569632ae447aaa2d080d5c7"
@@ -5341,7 +5375,7 @@
       "checksum": "313cc1a4bf9b97f780607d450e3d568d"
     },
     "DESCRIPTION": {
-      "checksum": "0a95752907176276f63bad94bda84b61"
+      "checksum": "0090600df9f6a5416fe5ee6466283ed0"
     },
     "Dockerfile": {
       "checksum": "854f110b4a917f5952c7b1b1f9cfa7d1"
@@ -5443,7 +5477,7 @@
       "checksum": "d50200e950a3a4fd684c98a75deaaeac"
     },
     "R/mod_calculate_fct_data.R": {
-      "checksum": "96b1d09169b093011e326b7270a2cfd6"
+      "checksum": "0c544fa940b2721c666a361cd8f35bc8"
     },
     "R/mod_calculate_fct_effect.R": {
       "checksum": "745269f777e61caec215ddeb7655b2c4"
@@ -5455,16 +5489,16 @@
       "checksum": "078f2a4358dd8083e0590d84af257649"
     },
     "R/mod_calculate.R": {
-      "checksum": "4075f54f955a82d1d7d06c8e789ce32f"
+      "checksum": "adae35736e9ef8840d78bc2c444b5679"
     },
     "R/mod_filter.R": {
-      "checksum": "06adeeb89ee5f97eb903c05636828fd2"
+      "checksum": "96e7d2f6e6090d2c59d16d6f84c7b48c"
     },
     "R/mod_graph_fct_plots.R": {
       "checksum": "e4a398dfa002d9226b1d5325b7e26279"
     },
     "R/mod_graph.R": {
-      "checksum": "491d5a3c54aab9b365f494fb0f5f4908"
+      "checksum": "7c1365fe235893839f446ad6c1b84e74"
     },
     "R/mod_heatmap_fct_plots.R": {
       "checksum": "f194ebd532c426a281c8549c8bf929d9"
@@ -5497,7 +5531,7 @@
       "checksum": "24754d50f0f1a7e1a727f6f3087f56c2"
     },
     "R/mod_upload.R": {
-      "checksum": "592cbb1a53e4fbb922a2e7897a77e0e0"
+      "checksum": "b29c89e67c75ffb2aa930b69b3bc6cb7"
     },
     "R/mod_volcano_fct_plots.R": {
       "checksum": "932784f5a1c80a5c65ba6937e45a190f"
@@ -5521,7 +5555,7 @@
       "checksum": "9cc164716ba66d5c1cecdaea5acffde2"
     },
     "renv.lock": {
-      "checksum": "b93b263bc9b74e596efbe4e49d059f55"
+      "checksum": "e6b6ef5d3fa7ea271d9b812b8b90536d"
     }
   },
   "users": null

--- a/renv.lock
+++ b/renv.lock
@@ -5002,6 +5002,39 @@
       "Maintainer": "Winston Chang <winston@posit.co>",
       "Repository": "CRAN"
     },
+    "shiny.destroy": {
+      "Package": "shiny.destroy",
+      "Version": "0.1.0",
+      "Source": "Repository",
+      "Type": "Package",
+      "Title": "Create Destroyable Modules in 'Shiny'",
+      "Authors@R": "person(\"Ashley\", \"Baldry\", email = \"arbaldry91@gmail.com\", role = c(\"aut\", \"cre\"))",
+      "Description": "Enables the complete removal of various 'Shiny' components, such as inputs, outputs and modules. It also aids in the removal of observers that have been  created in dynamically created modules.",
+      "License": "MIT + file LICENSE",
+      "Encoding": "UTF-8",
+      "Imports": [
+        "purrr",
+        "rlang",
+        "shiny"
+      ],
+      "Suggests": [
+        "bslib",
+        "htmltools",
+        "knitr",
+        "rmarkdown",
+        "shinytest2",
+        "spelling",
+        "testthat (>= 3.0.0)"
+      ],
+      "Config/testthat/edition": "3",
+      "Language": "en-GB",
+      "RoxygenNote": "7.3.2",
+      "VignetteBuilder": "knitr",
+      "NeedsCompilation": "no",
+      "Author": "Ashley Baldry [aut, cre]",
+      "Maintainer": "Ashley Baldry <arbaldry91@gmail.com>",
+      "Repository": "CRAN"
+    },
     "shinyWidgets": {
       "Package": "shinyWidgets",
       "Version": "0.9.0",


### PR DESCRIPTION
shiny::removeUI() only hides the UI element, but the HTML element persists. This can result in duplicated filter buttons and inconstant behavior.

shiny.destroy::removeInput() deletes the UI element completely and solves the issue.